### PR TITLE
bugfix: fix return type of callAPI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typesafe-api-call",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A TS/JS API caller util for making typesafe API calls",
   "main": "index.ts",
   "type": "module",

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,7 +1,7 @@
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import { createInterface } from 'readline';
-import packageJson from '../package.json' assert { type: 'json' };;
+import packageJson from '../package.json' assert { type: 'json' };
 import fs from 'fs';
 
 const _fs = fs.promises;
@@ -54,7 +54,10 @@ switch (version) {
 logWarning(`version set to ${newVersion}`);
 
 packageJson.version = newVersion;
-await _fs.writeFile('package.json', Buffer.from(JSON.stringify(packageJson, null, 2), 'utf-8'));
+await _fs.writeFile(
+  'package.json',
+  Buffer.from(JSON.stringify(packageJson, null, 2) + '\n', 'utf-8')
+);
 
 await _exec(`
   git add package.json &&

--- a/src/APICaller.ts
+++ b/src/APICaller.ts
@@ -11,7 +11,7 @@ import { APISuccess, APIFailure } from './types';
 
 export class APICaller {
   static startHooks: APICallStartHook[] = [];
-  static endHooks: Array<APICallEndHook<unknown>> = [];
+  static endHooks: Array<APICallEndHook<unknown, unknown>> = [];
 
   /**
    * @name APICaller.call
@@ -23,13 +23,13 @@ export class APICaller {
    * @returns An resolved Promise with Two Instances - APISuccess or APIFailure
    */
 
-  static async call<ExpectedResponse, ErrorResponse>(
+  static async call<SuccessResponse, ErrorResponse>(
     apiRequest: APIRequest,
-    responseDecoder: ResponseDecoder<ExpectedResponse>,
+    responseDecoder: ResponseDecoder<SuccessResponse>,
     errorResponseDecoder: ResponseDecoder<ErrorResponse | unknown> = (e) => e,
     apiCaller: FetchType = fetch
-  ): Promise<APIResponse<ExpectedResponse | ErrorResponse>> {
-    let result: APIResponse<ExpectedResponse | ErrorResponse>;
+  ): Promise<APIResponse<SuccessResponse, ErrorResponse>> {
+    let result: APIResponse<SuccessResponse, ErrorResponse>;
     try {
       this.startHooks.forEach((hook) => {
         hook(apiRequest);
@@ -71,7 +71,7 @@ export class APICaller {
     this.startHooks.push(hook);
   }
 
-  static registerEndHook(hook: APICallEndHook<unknown>): void {
+  static registerEndHook(hook: APICallEndHook<unknown, unknown>): void {
     this.endHooks.push(hook);
   }
 }

--- a/src/types/APIFailure.ts
+++ b/src/types/APIFailure.ts
@@ -3,10 +3,10 @@
  * @description Construct an API Error Instance.
  * @constructor Takes ErrorMessage String and Error Code Number
  */
-export class APIFailure {
+export class APIFailure<FailureResponseType> {
   readonly errorMessage: string;
   readonly errorCode: number;
-  readonly errorResponse: unknown;
+  readonly errorResponse: FailureResponseType | unknown;
   readonly time: number;
 
   constructor(errorMessage: string, errorCode: number, errorResponse: unknown, time: number) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,7 +22,9 @@ export interface APIRequest extends RequestInit {
  * @description Denotes all possible responses of an API call
  */
 
-export type APIResponse<ExpectedResponseType> = APISuccess<ExpectedResponseType> | APIFailure;
+export type APIResponse<SuccessResponseType, FailureResponseType> =
+  | APISuccess<SuccessResponseType>
+  | APIFailure<FailureResponseType>;
 
 export type ResponseDecoder<ExpectedResponse> = (rawResponse: unknown) => ExpectedResponse | null;
 
@@ -40,7 +42,7 @@ export type FetchType = (
 
 export type APICallStartHook = (apiRequest: APIRequest) => void;
 
-export type APICallEndHook<ResponseType> = (
+export type APICallEndHook<SuccessResponseType, FailureResponseType> = (
   apiRequest: APIRequest,
-  apiResponse: APIResponse<ResponseType>
+  apiResponse: APIResponse<SuccessResponseType, FailureResponseType>
 ) => void;


### PR DESCRIPTION
- Fixed the return type of callAPI to return SuccessResponse in APISuccess & FailureResponse in APIFailure
- Renamed types of SuccessResponse & ErrorResponse