### PR TITLE
feat: Improved error handling

### DIFF
--- a/src/types/APIFailure.ts
+++ b/src/types/APIFailure.ts
@@ -1,3 +1,5 @@
+import { ErrorDetails } from ".";
+
 /**
  * @name APIFailure
  * @description Construct an API Error Instance.
@@ -6,13 +8,17 @@
 export class APIFailure<FailureResponseType> {
   readonly errorMessage: string;
   readonly errorCode: number;
-  readonly errorResponse: FailureResponseType | unknown;
+  readonly response: FailureResponseType | null;
+  readonly errorResponse: unknown;
+  readonly errorDetails: ErrorDetails | null;
   readonly time: number;
 
-  constructor(errorMessage: string, errorCode: number, errorResponse: unknown, time: number) {
+  constructor(errorMessage: string, errorCode: number, response: FailureResponseType | null, errorResponse: unknown, time: number, errorDetails: ErrorDetails | null) {
     this.errorMessage = errorMessage;
     this.errorCode = errorCode;
+    this.response = response;
     this.errorResponse = errorResponse;
+    this.errorDetails = errorDetails;
     this.time = time;
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,9 @@ import type { APISuccess } from './APISuccess';
 export * from './APISuccess';
 export * from './APIFailure';
 
+/**
+ * @name HttpMethod
+ */
 export type HttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
 /**
@@ -26,9 +29,13 @@ export type APIResponse<SuccessResponseType, FailureResponseType> =
   | APISuccess<SuccessResponseType>
   | APIFailure<FailureResponseType>;
 
+/**
+ * @name ResponseDecoder
+ */
 export type ResponseDecoder<ExpectedResponse> = (rawResponse: unknown) => ExpectedResponse | null;
 
 /**
+ * @name FetchType
  * @description Type of native fetch function
  */
 export type FetchType = (input: RequestInfo, init?: RequestInit | undefined) => Promise<Response>;
@@ -38,12 +45,43 @@ export type FetchType = (input: RequestInfo, init?: RequestInit | undefined) => 
  * @description Takes two parameters id &
  */
 
+/**
+ * @name APICallStartHook
+ */
 export type APICallStartHook = { id: string; func: (apiRequest: APIRequest) => void };
 
+
+/**
+ * @name APICallEndHook
+ */
 export type APICallEndHook<SuccessResponseType, FailureResponseType> = {
   id: string;
   func: (
     apiRequest: APIRequest,
     apiResponse: APIResponse<SuccessResponseType, FailureResponseType>
   ) => void;
+};
+
+/**
+ * @name ErrorClass
+ * @description Classes of exceptions encountered during the fetch call or parsing network call response
+ */
+export type ErrorClass =
+  | 'DOMException'
+  | 'TypeError'
+  | 'DecodeFailure'
+  | 'InternalError'
+  | 'Error'
+  | 'UnhandledException';
+
+/**
+ * @name ErrorDetails
+ * @description Typed error response for additional info on type of error encountered during fetch call or parsing network call response
+ */
+export type ErrorDetails = {
+  class: ErrorClass;
+  name: string;
+  message: string | null;
+  cause: unknown;
+  stack: string | null;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { ErrorDetails } from './types';
+
 export async function generateRawResponse(apiResponse: Response): Promise<unknown> {
   let result = null;
   const contentType = apiResponse.headers.get('content-type');
@@ -7,4 +9,40 @@ export async function generateRawResponse(apiResponse: Response): Promise<unknow
     result = await apiResponse.text();
   }
   return result;
+}
+
+export function getErrorDetails(err: unknown): ErrorDetails {
+  if (err instanceof DOMException) {
+    return {
+      class: 'DOMException',
+      name: err.name,
+      message: err.message,
+      cause: err.cause,
+      stack: err.stack ?? null
+    };
+  } else if (err instanceof TypeError) {
+    return {
+      class: 'TypeError',
+      name: err.name,
+      message: err.message,
+      cause: err.cause,
+      stack: err.stack ?? null
+    };
+  } else if (err instanceof Error) {
+    return {
+      class: 'Error',
+      name: err.name,
+      message: err.message,
+      cause: JSON.stringify(err),
+      stack: err.stack ?? null
+    };
+  } else {
+    return {
+      class: 'UnhandledException',
+      name: 'UnhandledException',
+      message: null,
+      cause: JSON.stringify(err),
+      stack: null
+    };
+  }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "ES2022" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for TC39 stage 2 draft decorators. */
@@ -25,7 +25,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "es2020" /* Specify what module code is generated. */,
+    "module": "ES2022" /* Specify what module code is generated. */,
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
     "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
- Added error handling based on error instances based on MDN Specifications (Refer: https://developer.mozilla.org/en-US/docs/Web/API/fetch)
- Bumped build target to ES2022 to allow type-checking key `cause` on Error instance
- Added errorDetails key to APIFailure object
- Updated ErrorResponseDecoder param to be null by default